### PR TITLE
Switch to TOML for config format (again)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1826,6 +1826,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tokio",
+ "toml",
  "url",
 ]
 

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,6 +31,7 @@ parking_lot = "0.12.1"
 rust-keystore = { git = "https://github.com/andrewinci/rust-keystore", features = [
     "p12",
 ], tag = "v0.1.2" }
+toml = "0.5"
 
 [target.'cfg(windows)'.dependencies]
 rdkafka = { version = "0.29", features = [

--- a/src-tauri/src/api/error.rs
+++ b/src-tauri/src/api/error.rs
@@ -19,6 +19,7 @@ impl From<Error> for TauriError {
             Error::Kafka { message } => ("Kafka error", message),
             Error::SqlError { message } => ("SQLite error", message),
             Error::LegacyConfig { message } => ("Import legacy config error", message),
+            Error::TOMLSerde { message } => ("TOML Serde error", message),
         };
         TauriError {
             error_type: error_type.into(),

--- a/src-tauri/src/lib/configuration/config_store.rs
+++ b/src-tauri/src/lib/configuration/config_store.rs
@@ -38,7 +38,7 @@ impl ConfigStore {
             true => {
                 let raw_config = fs::read_to_string(&self.config_path)?;
                 let conf = toml::from_str::<StoreConfig>(&raw_config)?;
-                Ok(InsulatorConfig::from(conf))//FIXME implement froms
+                Ok(InsulatorConfig::from(conf))
             }
             // if the file doesn't exists return the default
             false => {

--- a/src-tauri/src/lib/configuration/mod.rs
+++ b/src-tauri/src/lib/configuration/mod.rs
@@ -2,6 +2,7 @@ mod config_store;
 mod kafka_client_config;
 mod legacy_config;
 mod types;
+mod store_types;
 
 pub use config_store::ConfigStore;
 pub use kafka_client_config::build_kafka_client_config;

--- a/src-tauri/src/lib/configuration/store_types.rs
+++ b/src-tauri/src/lib/configuration/store_types.rs
@@ -1,0 +1,161 @@
+use serde::{Deserialize, Serialize};
+
+use super::{AuthenticationConfig, ClusterConfig, InsulatorConfig, SchemaRegistryConfig, Theme};
+
+#[derive(Serialize, Deserialize, Debug, Default, PartialEq, Eq)]
+pub struct StoreConfig {
+    pub theme: Theme,
+    #[serde(rename = "showNotifications")]
+    pub show_notifications: bool,
+    #[serde(rename = "useRegex")]
+    pub use_regex: bool,
+    pub clusters: Vec<StoreCluster>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+pub struct StoreCluster {
+    pub id: String,
+    pub name: String,
+    pub endpoint: String,
+    pub authentication: StoreAuthentication,
+    #[serde(rename = "schemaRegistry")]
+    pub schema_registry: Option<SchemaRegistryConfig>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq)]
+#[serde(tag = "type")]
+pub enum StoreAuthentication {
+    Ssl {
+        ca: String,
+        certificate: String,
+        key: String,
+        #[serde(rename = "keyPassword")]
+        key_password: Option<String>,
+    },
+    Sasl {
+        username: String,
+        password: String,
+        scram: bool,
+    },
+    #[default]
+    None,
+}
+
+impl From<StoreAuthentication> for AuthenticationConfig {
+    fn from(s: StoreAuthentication) -> Self {
+        match s {
+            StoreAuthentication::Ssl {
+                ca,
+                certificate,
+                key,
+                key_password,
+            } => AuthenticationConfig::Ssl {
+                ca: ca,
+                certificate: certificate,
+                key: key,
+                key_password: key_password,
+            },
+            StoreAuthentication::Sasl {
+                username,
+                password,
+                scram,
+            } => AuthenticationConfig::Sasl {
+                username: username,
+                password: password,
+                scram: scram,
+            },
+            StoreAuthentication::None => AuthenticationConfig::None,
+        }
+    }
+}
+
+impl From<StoreCluster> for ClusterConfig {
+    fn from(
+        StoreCluster {
+            id,
+            name,
+            endpoint,
+            authentication,
+            schema_registry,
+        }: StoreCluster,
+    ) -> Self {
+        ClusterConfig {
+            id: id,
+            name: name,
+            endpoint: endpoint,
+            authentication: authentication.into(),
+            schema_registry: schema_registry,
+        }
+    }
+}
+
+impl From<StoreConfig> for InsulatorConfig {
+    fn from(
+        StoreConfig {
+            theme,
+            show_notifications,
+            use_regex,
+            clusters,
+        }: StoreConfig,
+    ) -> Self {
+        let converted_clusters = clusters.into_iter().map(|c| c.into()).collect();
+        InsulatorConfig {
+            theme: theme,
+            show_notifications: show_notifications,
+            use_regex: use_regex,
+            clusters: converted_clusters,
+        }
+    }
+}
+
+impl Into<StoreAuthentication> for AuthenticationConfig {
+    fn into(self) -> StoreAuthentication {
+        match self {
+            AuthenticationConfig::Ssl {
+                ca,
+                certificate,
+                key,
+                key_password,
+            } => StoreAuthentication::Ssl {
+                ca: ca,
+                certificate: certificate,
+                key: key,
+                key_password: key_password,
+            },
+            AuthenticationConfig::Sasl {
+                username,
+                password,
+                scram,
+            } => StoreAuthentication::Sasl {
+                username: username,
+                password: password,
+                scram: scram,
+            },
+            AuthenticationConfig::None => StoreAuthentication::None,
+        }
+    }
+}
+
+impl Into<StoreCluster> for ClusterConfig {
+    fn into(self) -> StoreCluster {
+        StoreCluster {
+            id: self.id,
+            name: self.name,
+            endpoint: self.endpoint,
+            authentication: self.authentication.into(),
+            schema_registry: self.schema_registry,
+        }
+    }
+}
+
+impl Into<StoreConfig> for &InsulatorConfig {
+    fn into(self) -> StoreConfig {
+        let conf = self.clone();
+        StoreConfig {
+            theme: conf.theme,
+            show_notifications: conf.show_notifications,
+            use_regex: conf.use_regex,
+            clusters: conf.clusters.clone().into_iter().map(|c| c.into()).collect(),
+        }
+    }
+}

--- a/src-tauri/src/lib/configuration/types.rs
+++ b/src-tauri/src/lib/configuration/types.rs
@@ -10,7 +10,7 @@ pub struct InsulatorConfig {
     pub clusters: Vec<ClusterConfig>,
 }
 
-#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum Theme {
     #[default]
     Dark,

--- a/src-tauri/src/lib/error.rs
+++ b/src-tauri/src/lib/error.rs
@@ -5,6 +5,7 @@ pub enum Error {
     AvroParse { message: String },
     IO { message: String },
     JSONSerde { message: String },
+    TOMLSerde { message: String},
     Consumer { message: String },
     Kafka { message: String },
     SqlError { message: String },
@@ -24,6 +25,22 @@ impl From<std::io::Error> for Error {
 impl From<serde_json::Error> for Error {
     fn from(error: serde_json::Error) -> Self {
         Error::JSONSerde {
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<toml::de::Error> for Error {
+    fn from(error: toml::de::Error) -> Self {
+        Error::TOMLSerde {
+            message: error.to_string(),
+        }
+    }
+}
+
+impl From<toml::ser::Error> for Error {
+    fn from(error: toml::ser::Error) -> Self {
+        Error::TOMLSerde {
             message: error.to_string(),
         }
     }


### PR DESCRIPTION
This time split out the model so config format can evolve independently of internal configuration.