### PR TITLE
refactor: abstract the query result

### DIFF
--- a/backend/src/api/types.rs
+++ b/backend/src/api/types.rs
@@ -1,10 +1,10 @@
 use serde::Serialize;
 
-use crate::core::record_store::QueryRow;
+use crate::core::record_store::QueryResultRow;
 
 #[derive(Serialize, Debug)]
 pub struct GetPageResponse {
-    pub records: Vec<QueryRow>,
+    pub records: Vec<QueryResultRow>,
     #[serde(rename = "nextPage")]
     pub next_page: Option<usize>,
     #[serde(rename = "prevPage")]

--- a/backend/src/api/types.rs
+++ b/backend/src/api/types.rs
@@ -1,10 +1,10 @@
 use serde::Serialize;
 
-use crate::core::types::ParsedKafkaRecord;
+use crate::core::record_store::QueryRow;
 
 #[derive(Serialize, Debug)]
 pub struct GetPageResponse {
-    pub records: Vec<ParsedKafkaRecord>,
+    pub records: Vec<QueryRow>,
     #[serde(rename = "nextPage")]
     pub next_page: Option<usize>,
     #[serde(rename = "prevPage")]

--- a/backend/src/core/admin/consumer_admin.rs
+++ b/backend/src/core/admin/consumer_admin.rs
@@ -65,7 +65,10 @@ impl KafkaAdmin {
     ) -> AdminResult<ConsumerGroupInfo> {
         // create a consumer with the defined consumer_group_name.
         // NOTE: the consumer shouldn't join the consumer group, otherwise it'll cause a re-balance
-        debug!("Build the consumer for tsumer group {}", consumer_group_name);
+        debug!(
+            "Build the consumer client for the specified consumer group {}",
+            consumer_group_name
+        );
         let consumer: BaseConsumer = build_kafka_client_config(&self.config, Some(consumer_group_name)).create()?;
 
         debug!("Build the topic/partition list");

--- a/backend/src/core/record_store/mod.rs
+++ b/backend/src/core/record_store/mod.rs
@@ -6,6 +6,6 @@ mod topic_store;
 pub mod types;
 
 pub use error::StoreError;
-pub use query::{QueryRow, QueryRowValue};
+pub use query::{QueryResultRow, QueryResultRowItem};
 pub use sqlite_store::SqliteStore;
 pub use topic_store::TopicStore;

--- a/backend/src/core/record_store/mod.rs
+++ b/backend/src/core/record_store/mod.rs
@@ -6,5 +6,6 @@ mod topic_store;
 pub mod types;
 
 pub use error::StoreError;
+pub use query::{QueryRow, QueryRowValue};
 pub use sqlite_store::SqliteStore;
 pub use topic_store::TopicStore;

--- a/backend/src/core/record_store/query.rs
+++ b/backend/src/core/record_store/query.rs
@@ -2,10 +2,6 @@ use std::collections::HashMap;
 
 use serde::Serialize;
 
-use crate::core::types::ParsedKafkaRecord;
-
-use super::{error::StoreResult, StoreError};
-
 #[derive(Debug)]
 pub struct Query {
     pub cluster_id: String,
@@ -16,7 +12,13 @@ pub struct Query {
 }
 
 impl Query {
-    pub const SELECT_WITH_OFFSET_LIMIT_QUERY : &str = "SELECT partition, offset, timestamp, key, payload FROM {:topic} ORDER BY timestamp desc LIMIT {:limit} OFFSET {:offset}";
+    pub const PARTITION: &str = "partition";
+    pub const OFFSET: &str = "offset";
+    pub const TIMESTAMP: &str = "timestamp";
+    pub const KEY: &str = "key";
+    pub const PAYLOAD: &str = "payload";
+    pub const SELECT_ALL_WITH_OFFSET_LIMIT_QUERY: &str =
+        "SELECT * FROM {:topic} ORDER BY timestamp desc LIMIT {:limit} OFFSET {:offset}";
 
     #[cfg(test)]
     pub fn select_any(cluster_id: &str, topic_name: &str, offset: i64, limit: i64) -> Query {
@@ -25,7 +27,7 @@ impl Query {
             topic_name: topic_name.into(),
             limit,
             offset,
-            query_template: Query::SELECT_WITH_OFFSET_LIMIT_QUERY.into(),
+            query_template: Query::SELECT_ALL_WITH_OFFSET_LIMIT_QUERY.into(),
         }
     }
 }

--- a/backend/src/core/record_store/query.rs
+++ b/backend/src/core/record_store/query.rs
@@ -15,7 +15,9 @@ pub struct Query {
 }
 
 impl Query {
+    #[cfg(test)]
     pub const PARTITION: &str = "partition";
+    #[cfg(test)]
     pub const OFFSET: &str = "offset";
     pub const TIMESTAMP: &str = "timestamp";
     pub const KEY: &str = "key";
@@ -35,9 +37,9 @@ impl Query {
     }
 }
 
-pub type QueryRow = HashMap<String, QueryRowValue>;
+pub type QueryResultRow = HashMap<String, QueryResultRowItem>;
 #[derive(Debug, Clone)]
-pub enum QueryRowValue {
+pub enum QueryResultRowItem {
     Null,
     Integer(i64),
     Real(f64),
@@ -45,9 +47,9 @@ pub enum QueryRowValue {
     Blob(Vec<u8>),
 }
 
-impl QueryRowValue {
+impl QueryResultRowItem {
     pub fn extract_timestamp(&self, parse_timestamp: bool) -> String {
-        if let QueryRowValue::Integer(unix_timestamp) = self {
+        if let QueryResultRowItem::Integer(unix_timestamp) = self {
             if parse_timestamp {
                 // Creates a new SystemTime from the specified number of whole seconds
                 let d = UNIX_EPOCH + Duration::from_millis(unix_timestamp.to_u64().unwrap());
@@ -62,29 +64,29 @@ impl QueryRowValue {
     }
 }
 
-impl ToString for QueryRowValue {
+impl ToString for QueryResultRowItem {
     fn to_string(&self) -> String {
         match self {
-            QueryRowValue::Null => "null".to_string(),
-            QueryRowValue::Integer(v) => v.to_string(),
-            QueryRowValue::Real(v) => v.to_string(),
-            QueryRowValue::Text(v) => v.to_string(),
-            QueryRowValue::Blob(_) => "byte array".to_string(), //todo: support
+            QueryResultRowItem::Null => "null".to_string(),
+            QueryResultRowItem::Integer(v) => v.to_string(),
+            QueryResultRowItem::Real(v) => v.to_string(),
+            QueryResultRowItem::Text(v) => v.to_string(),
+            QueryResultRowItem::Blob(_) => "byte array".to_string(), //todo: support
         }
     }
 }
 
-impl Serialize for QueryRowValue {
+impl Serialize for QueryResultRowItem {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: serde::Serializer,
     {
         match self {
-            QueryRowValue::Integer(v) => serializer.serialize_i64(*v),
-            QueryRowValue::Real(v) => serializer.serialize_f64(*v),
-            QueryRowValue::Text(v) => serializer.serialize_str(v),
-            QueryRowValue::Blob(v) => serializer.serialize_bytes(v),
-            QueryRowValue::Null => serializer.serialize_none(),
+            QueryResultRowItem::Integer(v) => serializer.serialize_i64(*v),
+            QueryResultRowItem::Real(v) => serializer.serialize_f64(*v),
+            QueryResultRowItem::Text(v) => serializer.serialize_str(v),
+            QueryResultRowItem::Blob(v) => serializer.serialize_bytes(v),
+            QueryResultRowItem::Null => serializer.serialize_none(),
         }
     }
 }

--- a/backend/src/core/record_store/query.rs
+++ b/backend/src/core/record_store/query.rs
@@ -1,3 +1,11 @@
+use std::collections::HashMap;
+
+use serde::Serialize;
+
+use crate::core::types::ParsedKafkaRecord;
+
+use super::{error::StoreResult, StoreError};
+
 #[derive(Debug)]
 pub struct Query {
     pub cluster_id: String,
@@ -19,5 +27,64 @@ impl Query {
             offset,
             query_template: Query::SELECT_WITH_OFFSET_LIMIT_QUERY.into(),
         }
+    }
+}
+
+pub type QueryRow = HashMap<String, QueryRowValue>;
+#[derive(Debug, Clone)]
+pub enum QueryRowValue {
+    Null,
+    Integer(i64),
+    Real(f64),
+    Text(String),
+    Blob(Vec<u8>),
+}
+
+impl QueryRowValue {
+    fn try_get_string(&self) -> StoreResult<String> {
+        if let QueryRowValue::Text(res) = self {
+            Ok(res.to_owned())
+        } else {
+            Err(StoreError::RecordParse(format!(
+                "Expected string value but got {self:?}"
+            )))
+        }
+    }
+}
+
+impl Serialize for QueryRowValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            QueryRowValue::Integer(v) => serializer.serialize_i64(*v),
+            QueryRowValue::Real(v) => serializer.serialize_f64(*v),
+            QueryRowValue::Text(v) => serializer.serialize_str(v),
+            QueryRowValue::Blob(v) => serializer.serialize_bytes(v),
+            QueryRowValue::Null => serializer.serialize_none(),
+        }
+    }
+}
+
+impl TryFrom<QueryRow> for ParsedKafkaRecord {
+    type Error = StoreError;
+
+    fn try_from(value: QueryRow) -> Result<Self, Self::Error> {
+        //todo: parsing and error handling
+        Ok(ParsedKafkaRecord {
+            payload: match value.get("payload") {
+                Some(r) => Some(r.try_get_string()?),
+                None => None,
+            },
+            key: match value.get("key") {
+                Some(r) => Some(r.try_get_string()?),
+                None => None,
+            },
+            topic: value.get("topic").unwrap().try_get_string()?.clone(),
+            timestamp: Some(1), // value.get("timestamp").cloned(),
+            partition: 2,       //value.get("partition").cloned(),
+            offset: 3,          //value.get("offset").cloned(),
+        })
     }
 }

--- a/backend/src/core/record_store/query.rs
+++ b/backend/src/core/record_store/query.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
+use rust_decimal::prelude::ToPrimitive;
 use serde::Serialize;
+use std::time::{Duration, UNIX_EPOCH};
+use time::format_description::well_known;
 
 #[derive(Debug)]
 pub struct Query {
@@ -40,6 +43,23 @@ pub enum QueryRowValue {
     Real(f64),
     Text(String),
     Blob(Vec<u8>),
+}
+
+impl QueryRowValue {
+    pub fn extract_timestamp(&self, parse_timestamp: bool) -> String {
+        if let QueryRowValue::Integer(unix_timestamp) = self {
+            if parse_timestamp {
+                // Creates a new SystemTime from the specified number of whole seconds
+                let d = UNIX_EPOCH + Duration::from_millis(unix_timestamp.to_u64().unwrap());
+                // Create DateTime from SystemTime
+                time::OffsetDateTime::from(d).format(&well_known::Rfc3339).unwrap()
+            } else {
+                unix_timestamp.to_string()
+            }
+        } else {
+            self.to_string()
+        }
+    }
 }
 
 impl ToString for QueryRowValue {

--- a/backend/src/core/record_store/sqlite_store.rs
+++ b/backend/src/core/record_store/sqlite_store.rs
@@ -513,12 +513,12 @@ mod tests {
 
     fn parse_row(row: &QueryRow, topic_name: &str) -> ParsedKafkaRecord {
         ParsedKafkaRecord {
-            payload: match row.get("payload") {
+            payload: match row.get(Query::PAYLOAD) {
                 None => None,
                 Some(crate::core::record_store::QueryRowValue::Text(v)) => Some(v.to_string()),
                 _ => panic!("invalid type"),
             },
-            key: match row.get("key") {
+            key: match row.get(Query::KEY) {
                 None => None,
                 Some(crate::core::record_store::QueryRowValue::Text(v)) => Some(v.to_string()),
                 _ => panic!("invalid type"),
@@ -526,16 +526,16 @@ mod tests {
             // the topic name is not part of the table since can be retrieved
             // by the table name
             topic: topic_name.into(),
-            timestamp: match row.get("timestamp") {
+            timestamp: match row.get(Query::TIMESTAMP) {
                 None => None,
                 Some(crate::core::record_store::QueryRowValue::Integer(v)) => Some((*v).try_into().unwrap()),
                 _ => panic!("invalid type"),
             },
-            partition: match row.get("partition") {
+            partition: match row.get(Query::PARTITION) {
                 Some(crate::core::record_store::QueryRowValue::Integer(v)) => (*v).try_into().unwrap(),
                 _ => panic!("invalid type"),
             },
-            offset: match row.get("offset") {
+            offset: match row.get(Query::OFFSET) {
                 Some(crate::core::record_store::QueryRowValue::Integer(v)) => *v,
                 _ => panic!("invalid type"),
             },

--- a/backend/src/core/record_store/sqlite_store.rs
+++ b/backend/src/core/record_store/sqlite_store.rs
@@ -62,12 +62,12 @@ impl RecordStore for SqliteStore {
             .execute(
                 format!(
                     "CREATE TABLE {} (
+                        payload     TEXT,
+                        key         TEXT {},
+                        timestamp   NUMBER,
                         partition   NUMBER,
                         offset      NUMBER,
-                        timestamp   NUMBER,
-                        key         TEXT {},
-                        payload     TEXT,
-                        PRIMARY KEY (partition, offset))",
+                    PRIMARY KEY (partition, offset))",
                     Self::get_table_name(cluster_id, topic_name),
                     match compacted {
                         true => "UNIQUE",
@@ -85,17 +85,17 @@ impl RecordStore for SqliteStore {
         let connection = self.pool.get().unwrap();
         connection.execute(
             format!(
-                "INSERT OR REPLACE INTO {} (partition, offset, timestamp, key, payload) 
-                VALUES (:partition, :offset, :timestamp, :key, :payload)",
+                "INSERT OR REPLACE INTO {} (payload, key, timestamp, partition, offset) 
+                VALUES (:payload, :key, :timestamp, :partition, :offset)",
                 Self::get_table_name(cluster_id, topic_name)
             )
             .as_str(),
             named_params! {
+                ":payload": &record.payload,
+                ":key": &record.key,
+                ":timestamp": &record.timestamp,
                 ":partition": &record.partition,
                 ":offset": &record.offset,
-                ":timestamp": &record.timestamp,
-                ":key": &record.key,
-                ":payload": &record.payload,
             },
         )?;
         Ok(())

--- a/backend/src/core/record_store/sqlite_store.rs
+++ b/backend/src/core/record_store/sqlite_store.rs
@@ -320,7 +320,7 @@ mod tests {
                 .unwrap();
             // assert
             assert_eq!(records_back.len(), 1);
-            assert_eq!(parse_row(&records_back[0], &test_record1.topic), test_record1);
+            assert_eq!(parse_row(&records_back[0], &test_record2.topic), test_record2);
         }
         // non compacted table should persist all the data
         {

--- a/backend/src/core/record_store/topic_store.rs
+++ b/backend/src/core/record_store/topic_store.rs
@@ -123,7 +123,15 @@ impl<S: RecordStore, P: KafkaRecordParser> TopicStore<S, P> {
                 writer.write_all(b"\n")?;
                 let row: Vec<_> = columns
                     .iter()
-                    .map(|c| record.get(c).map(|v| v.to_string()).unwrap_or_default())
+                    .map(|c| {
+                        record
+                            .get(c)
+                            .map(|v| match c.as_str() {
+                                Query::TIMESTAMP => v.extract_timestamp(*parse_timestamp),
+                                _ => v.to_string(),
+                            })
+                            .unwrap_or_default()
+                    })
                     .collect();
                 // todo: support parse timestamp
                 writer.write_all(row.join(SEPARATOR).to_bytes())?;

--- a/backend/src/core/record_store/topic_store.rs
+++ b/backend/src/core/record_store/topic_store.rs
@@ -12,7 +12,7 @@ use std::{
 
 use super::{
     error::StoreResult,
-    query::{Query, QueryRow},
+    query::{Query, QueryResultRow},
     record_parser::KafkaRecordParser,
     sqlite_store::{RecordStore, SqliteStore},
     types::ExportOptions,
@@ -52,7 +52,7 @@ impl<S: RecordStore, P: KafkaRecordParser> TopicStore<S, P> {
         offset: i64,
         limit: i64,
         timeout: Option<Duration>,
-    ) -> StoreResult<Vec<QueryRow>> {
+    ) -> StoreResult<Vec<QueryResultRow>> {
         self.store.query_records(
             &Query {
                 cluster_id: self.cluster_id.clone(),
@@ -180,12 +180,12 @@ mod test {
 
     use super::TopicStore;
     use crate::core::record_store::error::StoreResult;
-    use crate::core::record_store::query::{Query, QueryRow};
+    use crate::core::record_store::query::{Query, QueryResultRow};
     use crate::core::record_store::record_parser::KafkaRecordParser;
     use crate::core::record_store::sqlite_store::RecordStore;
     use crate::core::record_store::topic_store::sort_columns;
     use crate::core::record_store::types::ExportOptions;
-    use crate::core::record_store::QueryRowValue;
+    use crate::core::record_store::QueryResultRowItem;
     use crate::core::types::{ParsedKafkaRecord, RawKafkaRecord};
     use async_trait::async_trait;
 
@@ -199,7 +199,7 @@ mod test {
     mock! {
         Store {}
         impl RecordStore for Store {
-            fn query_records(&self, query: &Query, timeout: Option<Duration>) -> StoreResult<Vec<QueryRow>>;
+            fn query_records(&self, query: &Query, timeout: Option<Duration>) -> StoreResult<Vec<QueryResultRow>>;
             fn create_or_replace_topic_table(&self, cluster_id: &str, topic_name: &str, compacted: bool) -> StoreResult<()>;
             fn insert_record(&self, cluster_id: &str, topic_name: &str, record: &ParsedKafkaRecord) -> StoreResult<()>;
             fn destroy(&self, cluster_id: &str, topic_name: &str) -> StoreResult<()>;
@@ -348,13 +348,13 @@ mod test {
         }
     }
 
-    fn create_test_record(i: i32) -> QueryRow {
+    fn create_test_record(i: i32) -> QueryResultRow {
         HashMap::from([
-            (Query::PAYLOAD.into(), QueryRowValue::Text("payload".into())),
-            (Query::KEY.into(), QueryRowValue::Text("key".into())),
-            (Query::TIMESTAMP.into(), QueryRowValue::Integer(123123)),
-            (Query::PARTITION.into(), QueryRowValue::Integer(i.into())),
-            (Query::OFFSET.into(), QueryRowValue::Integer(0)),
+            (Query::PAYLOAD.into(), QueryResultRowItem::Text("payload".into())),
+            (Query::KEY.into(), QueryResultRowItem::Text("key".into())),
+            (Query::TIMESTAMP.into(), QueryResultRowItem::Integer(123123)),
+            (Query::PARTITION.into(), QueryResultRowItem::Integer(i.into())),
+            (Query::OFFSET.into(), QueryResultRowItem::Integer(0)),
         ])
     }
 }

--- a/backend/src/core/types.rs
+++ b/backend/src/core/types.rs
@@ -1,7 +1,4 @@
-use std::time::{Duration, UNIX_EPOCH};
-
 use serde::{Deserialize, Serialize};
-use time::format_description::well_known;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct KafkaRecord<T> {

--- a/backend/src/core/types.rs
+++ b/backend/src/core/types.rs
@@ -30,31 +30,3 @@ pub enum ParserMode {
 
 pub type RawKafkaRecord = KafkaRecord<Vec<u8>>;
 pub type ParsedKafkaRecord = KafkaRecord<String>;
-
-impl ParsedKafkaRecord {
-    pub fn to_csv_line(&self, parse_timestamp: bool) -> String {
-        let unix_timestamp = self.timestamp.unwrap_or_default();
-        let timestamp = if parse_timestamp {
-            // Creates a new SystemTime from the specified number of whole seconds
-            let d = UNIX_EPOCH + Duration::from_millis(unix_timestamp);
-            // Create DateTime from SystemTime
-            time::OffsetDateTime::from(d).format(&well_known::Rfc3339).unwrap()
-        } else {
-            unix_timestamp.to_string()
-        };
-        format!(
-            "{};{};{};{};{}",
-            timestamp,
-            self.partition,
-            self.offset,
-            self.key.clone().unwrap_or_default(),
-            self.payload.clone().unwrap_or_default()
-        )
-    }
-}
-
-impl ParsedKafkaRecord {
-    pub(crate) fn to_string_header() -> String {
-        format!("{};{};{};{};{}", "timestamp", "partition", "offset", "key", "payload")
-    }
-}

--- a/backend/src/core/types.rs
+++ b/backend/src/core/types.rs
@@ -14,7 +14,12 @@ pub struct KafkaRecord<T> {
     pub timestamp: Option<u64>,
     pub partition: i32,
     pub offset: i64,
-    //todo: headers
+    /*
+     * todo: add
+     * - header
+     * - record size
+     * - schema-id
+     */
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/frontend/src/pages/topics/topic/main.tsx
+++ b/frontend/src/pages/topics/topic/main.tsx
@@ -27,8 +27,7 @@ export const Topic = (props: TopicProps & JSX.IntrinsicAttributes) => {
     {
       key: `topic-page-${clusterId}-${topicName}`,
       initialValue: {
-        query: `SELECT partition, offset, timestamp, key, payload
-FROM {:topic}
+        query: `SELECT * FROM {:topic}
 -- query by json fields with the json_extract function
 -- WHERE json_extract(payload, "$.fieldName") = "something"
 ORDER BY timestamp desc LIMIT {:limit} OFFSET {:offset}

--- a/frontend/src/pages/topics/topic/topic-page-menu.tsx
+++ b/frontend/src/pages/topics/topic/topic-page-menu.tsx
@@ -40,8 +40,7 @@ export const TopicPageMenu = (props: TopicPageMenuProps) => {
   const onSimpleSearchTextChange = (text: string) => {
     setSimpleSearchText(text);
     text = text.trim();
-    onQueryChange(`SELECT partition, offset, timestamp, key, payload 
-FROM {:topic}
+    onQueryChange(`SELECT * FROM {:topic}
 -- query by json fields with the json_extract function
 -- WHERE json_extract(payload, "$.fieldName") = "something"
 WHERE key like '%${text}%' OR payload like '%${text}%'


### PR DESCRIPTION
Abstract the query result to a vec of maps in order to:
- easily extend the table with additional data (like the record headers, the record size or the schema used to parse the record)
- simplify the query the user need to write and reduce the number of errors
