### PR TITLE
fix: ingore set windows min size when in full screen

### DIFF
--- a/frontend/src/tauri/helpers.ts
+++ b/frontend/src/tauri/helpers.ts
@@ -29,7 +29,7 @@ export const usePlatform = (): Platform | undefined => {
 };
 
 export const setWindowMinSize = (width: number, height: number): void => {
-  appWindow.setMinSize(new LogicalSize(width, height));
+  if (!appWindow.isFullscreen()) appWindow.setMinSize(new LogicalSize(width, height));
 };
 
 export const setWindowTitle = (title: string): void => {


### PR DESCRIPTION
In Win, when the windows is full screen, calling the `setMinSize` from tauri causes the window to move and stop to be in full screen.